### PR TITLE
fix: cmd.js import error

### DIFF
--- a/src/cmd.js
+++ b/src/cmd.js
@@ -2,7 +2,7 @@
 
 const program = require('commander');
 const package = require('../package.json');
-const { client } = require('../src/index');
+const client = require('../src/index');
 
 program
     .requiredOption('-i, --id <number>', '输入房间id')


### PR DESCRIPTION
#45 这个 PR 更改了 index.js 的导出方式，但是 cmd.js 仍然按照以下方式导入 client，导致命令行执行的时候会抛 `not a constructor `异常
https://github.com/flxxyz/douyudm/blob/87a01161aa4eef71d961443f428879d3a7b385db/src/cmd.js#L5